### PR TITLE
Build and enable pfind by default

### DIFF
--- a/io500.sh
+++ b/io500.sh
@@ -89,9 +89,9 @@ function setup_find {
   #    If a custom approach is used, please provide enough info so others can reproduce.
 
   # the serial version that should run (SLOWLY) without modification
-  io500_find_mpi="False"
-  io500_find_cmd=$PWD/bin/sfind.sh
-  io500_find_cmd_args=""
+  #io500_find_mpi="False"
+  #io500_find_cmd=$PWD/bin/sfind.sh
+  #io500_find_cmd_args=""
 
   # a parallel version in C, the -s adds a stonewall
   #   for a real run, turn -s (stonewall) off or set it at 300 or more
@@ -106,9 +106,10 @@ function setup_find {
   #   Then you can set io500_find_mpi to be "False" and write a wrapper
   #   script for this which sets up MPI as you would like.  Then change
   #   io500_find_cmd to point to your wrapper script.
-  #io500_find_mpi="True"
-  #io500_find_cmd="$PWD/bin/pfind"
-  #io500_find_cmd_args="-r $io500_result_dir/pfind_results -s 30" # uses a 30 s stonewalling, run pfind for at most 30 seconds.
+  io500_find_mpi="True"
+  io500_find_cmd="$PWD/bin/pfind"
+  # uses a 300s stonewalling, run pfind for at most 300 seconds.
+  io500_find_cmd_args="-s 300 -r $io500_result_dir/pfind_results"
 
   # for GPFS systems, you should probably use the provided mmfind wrapper
   # if you used ./utilities/prepare.sh, you'll find this wrapper in ./bin/mmfind.sh

--- a/utilities/prepare.sh
+++ b/utilities/prepare.sh
@@ -24,7 +24,7 @@ function main {
   #get_mdrealio || true  # this failed on RHEL 7.4 so turning off until fixed
 
   build_ior
- # build_pfind   # unnecessary since it is a Python 3 program
+  build_pfind
 #  build_mdrealio || true  # this failed on RHEL 7.4 so turning off until fixed
 
   echo
@@ -96,7 +96,7 @@ function build_pfind {
   ./prepare.sh
   ./compile.sh
   cp pfind $BIN
-  echo "IOR: OK"
+  echo "Pfind: OK"
   echo
   popd
 }


### PR DESCRIPTION
The pfind program is no longer in python, so it needs to be
downloaded and built to be usable.  There is no point in using
the serial find by default, since pfind will always be faster, and
that is just one more step needed by a user to get a good score.

Signed-off-by: Andreas Dilger <adilger@dilger.ca>