### PR TITLE
Check that the results are valid for IO-500 submission

### DIFF
--- a/io500.sh
+++ b/io500.sh
@@ -61,7 +61,11 @@ function setup_paths {
 }
 
 function setup_ior_easy {
-  io500_ior_easy_params="-t 2048k -b 2g -F" # 2M writes, 2 GB per proc, file per proc
+  # io500_ior_easy_size is the amount of data written per rank in MiB units,
+  # but it can be any number as long as it is somehow used to scale the IOR
+  # runtime as part of io500_ior_easy_params
+  io500_ior_easy_size=2048
+  io500_ior_easy_params="-t 2048k -b ${io500_ior_easy_size}m -F" # 2M writes, 2 GB per proc, file per proc
 }
 
 function setup_mdt_easy {

--- a/utilities/io500_fixed.sh
+++ b/utilities/io500_fixed.sh
@@ -42,7 +42,7 @@ function output_description {
 }
 
 function check_variables {
-  local important_vars="io500_workdir io500_ior_easy_params io500_mdtest_hard_files_per_proc io500_ior_hard_writes_per_proc io500_find_cmd io500_ior_cmd io500_mdtest_cmd io500_mpirun"
+  local important_vars="io500_workdir io500_ior_easy_params io500_ior_easy_size io500_mdtest_hard_files_per_proc io500_ior_hard_writes_per_proc io500_find_cmd io500_ior_cmd io500_mdtest_cmd io500_mpirun"
 
   for V in $important_vars; do
     [ -z "${!V}" -o "${!V}" = "xxx" ] &&
@@ -88,10 +88,10 @@ function ior_easy {
   if [[ "$1" == "write" ]] ; then
     startphase
     myrun "$io500_ior_cmd -w $params_ior_easy" $result_file
-    endphase_check "write"
+    endphase_check "write" "io500_ior_easy_size"
     bw1=$(get_ior_bw $result_file "write")
     dur=$(get_ior_time $result_file "write")
-    print_bw 1 $bw1 $dur
+    print_bw 1 $bw1 $dur "$invalid"
   else
     [ "$io500_run_ior_easy_read" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
@@ -99,7 +99,7 @@ function ior_easy {
     endphase_check "read"
     bw3=$(get_ior_bw $result_file "read")
     dur=$(get_ior_time $result_file "read")
-    print_bw 3 $bw3 $dur
+    print_bw 3 $bw3 $dur "$invalid"
   fi
 }
 
@@ -113,23 +113,23 @@ function mdt_easy {
   if [[ "$1" == "write" ]] ; then
     startphase
     myrun "$io500_mdtest_cmd -C $params_md_easy" $result_file
-    endphase_check "write"
+    endphase_check "write" "io500_mdtest_easy_files_per_proc"
     iops1=$( get_mdt_iops $result_file "creation" )
-    print_iops 1 $iops1 $duration
+    print_iops 1 $iops1 $duration "$invalid"
   elif [[ "$1" == "stat" ]] ; then
     [ "$io500_run_md_easy_stat" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
     myrun "$io500_mdtest_cmd -T $params_md_easy" $result_file
     endphase_check "stat"
     iops4=$( get_mdt_iops $result_file "stat" )
-    print_iops 4 $iops4 $duration
+    print_iops 4 $iops4 $duration "$invalid"
   else
     [ "$io500_run_md_easy_delete" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
     myrun "$io500_mdtest_cmd -r $params_md_easy" $result_file
     endphase_check "delete"
     iops6=$( get_mdt_iops $result_file "removal" )
-    print_iops 6 $iops6 $duration
+    print_iops 6 $iops6 $duration "$invalid"
   fi
 }
 
@@ -137,16 +137,16 @@ function ior_hard {
   phase="ior_hard_$1"
   [ "$io500_run_ior_hard" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
 
-  params_ior_hard="-C -Q 1 -g -G 27 -k -e -t 47008 -b 47008 -s $io500_ior_hard_writes_per_proc  $io500_ior_hard_other_options -o $io500_workdir/ior_hard/IOR_file"
+  params_ior_hard="-C -Q 1 -g -G 27 -k -e -t 47008 -b 47008 -s $io500_ior_hard_writes_per_proc $io500_ior_hard_other_options -o $io500_workdir/ior_hard/IOR_file"
   result_file="$io500_result_dir/$phase.txt"
 
   if [[ "$1" == "write" ]] ; then
     startphase
     myrun "$io500_ior_cmd -w $params_ior_hard" $result_file
-    endphase_check "write"
+    endphase_check "write" "io500_ior_hard_writes_per_proc"
     bw2=$(get_ior_bw $result_file "write")
     dur=$(get_ior_time $result_file "write")
-    print_bw 2 $bw2 $dur
+    print_bw 2 $bw2 $dur "$invalid"
   else
     [ "$io500_run_ior_hard_read" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
@@ -154,7 +154,7 @@ function ior_hard {
     endphase_check "read"
     bw4=$(get_ior_bw $result_file "read")
     dur=$(get_ior_time $result_file "read")
-    print_bw 4 $bw4 $dur
+    print_bw 4 $bw4 $dur "$invalid"
   fi
 }
 
@@ -168,30 +168,30 @@ function mdt_hard {
   if [[ "$1" == "write" ]] ; then
     startphase $phase
     myrun "$io500_mdtest_cmd -C $params_md_hard" $result_file
-    endphase_check "write"
+    endphase_check "write" "io500_mdtest_files_per_proc"
     iops2=$( get_mdt_iops $result_file "creation" )
-    print_iops 2 $iops2 $duration
+    print_iops 2 $iops2 $duration "$invalid"
   elif [[ "$1" == "stat" ]] ; then
     [ "$io500_run_md_hard_stat" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
     myrun "$io500_mdtest_cmd -T $params_md_hard" $result_file
     endphase_check "stat"
     iops5=$( get_mdt_iops $result_file "stat" )
-    print_iops 5 $iops5 $duration
+    print_iops 5 $iops5 $duration "$invalid"
   elif [[ "$1" == "read" ]] ; then
     [ "$io500_run_md_hard_read" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
     myrun "$io500_mdtest_cmd -E $params_md_hard" $result_file
     endphase_check "read"
     iops7=$( get_mdt_iops $result_file "read" )
-    print_iops 7 $iops7 $duration
+    print_iops 7 $iops7 $duration "$invalid"
   else
     [ "$io500_run_md_hard_delete" != "True" ] && printf "\n[Skipping] $phase\n" && return 0
     startphase
     myrun "$io500_mdtest_cmd -r $params_md_hard" $result_file
     endphase_check "delete"
     iops8=$( get_mdt_iops $result_file "removal" )
-    print_iops 8 $iops8 $duration
+    print_iops 8 $iops8 $duration "$invalid"
   fi
 }
 
@@ -222,7 +222,7 @@ function myfind {
   totalfiles=`echo $matches | cut -d \/ -f 2`
   iops3=`echo "scale = 2; ($totalfiles / $duration)/1000" | bc`
   echo "[FIND] $matches in $duration seconds"
-  print_iops 3 $iops3 $duration
+  print_iops 3 $iops3 $duration "$invalid"
 }
 
 function output_score {
@@ -235,43 +235,54 @@ function output_score {
   bw_score=`echo $bw1 $bw2 $bw3 $bw4 | awk '{print ($1*$2*$3*$4)^(1/4)}'`
   md_score=`echo $iops1 $iops2 $iops3 $iops4 $iops5 $iops6 $iops7 $iops8 | awk '{print ($1*$2*$3*$4*$5*$6*$7*$8)^(1/8)}'`
   tot_score=`echo $bw_score $md_score | awk '{print ($1*$2)^(1/2)}'`
-  echo "[SCORE] Bandwidth $bw_score GB/s : IOPS $md_score kiops : TOTAL $tot_score" | tee -a $summary_file
   if [ "$io500_run_ior_easy" != "True" ] ; then
-    echo "IOR Easy Write skipped. No aggregate score possible."
+    echo "IOR Easy Write skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_easy" != "True" ] ; then
-    echo "MD Easy Create skipped. No aggregate score possible."
+    echo "MD Easy Create skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_ior_hard" != "True" ] ; then
-    echo "IOR Hard Write skipped. No aggregate score possible."
+    echo "IOR Hard Write skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_hard" != "True" ] ; then
-    echo "MD Hard Create skipped. No aggregate score possible."
+    echo "MD Hard Create skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_find" != "True" ] ; then
-    echo "Find skipped. No aggregate score possible."
+    echo "Find skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_ior_easy_read" != "True" ] ; then
-    echo "IOR Easy Read skipped. No aggregate score possible."
+    echo "IOR Easy Read skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_easy_stat" != "True" ] ; then
-    echo "MD Easy Stat skipped. No aggregate score possible."
+    echo "MD Easy Stat skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_ior_hard_read" != "True" ] ; then
-    echo "IOR Hard Read skipped. No aggregate score possible."
+    echo "IOR Hard Read skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_hard_stat" != "True" ] ; then
-    echo "MD Hard Stat skipped. No aggregate score possible."
-  fi
-  if [ "$io500_run_md_hard_read" != "True" ] ; then
-    echo "MD Hard Read skipped. No aggregate score possible."
+    echo "MD Hard Stat skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_easy_delete" != "True" ] ; then
-    echo "MD Easy Delete skipped. No aggregate score possible."
+    echo "MD Easy Delete skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
   if [ "$io500_run_md_hard_delete" != "True" ] ; then
-    echo "MD Hard Delete skipped. No aggregate score possible."
+    echo "MD Hard Delete skipped. Aggregate score is not valid."
+    io500_invalid="-invalid"
   fi
+  if [ -n "$io500_invalid" ]; then
+    echo "One or more test phases invalid.  Not valid for IO-500 submission."
+  fi
+  echo "[SCORE$io500_invalid] Bandwidth $bw_score GB/s : IOPS $md_score kiops : TOTAL $tot_score" | tee -a $summary_file
 }
 
 function core_setup {
@@ -286,14 +297,15 @@ function core_setup {
   iops1=0;iops2=0;iops3=0;iops4=0;iops5=0;iops6=0;iops7=0;iops8=0
   bw1=0;bw2=0;bw3=0;bw4=0
   mdt_hard_fsize=3901
+  io500_invalid=""
 }
 
 function print_bw  {
-  printf "[RESULT] BW   phase $1 %25s %20.3f GB/s : time %6.2f seconds\n" $phase $2 $3 | tee -a $summary_file
+  printf "[RESULT$4] BW   phase $1 %25s %20.3f GB/s : time %6.2f seconds\n" $phase $2 $3 | tee -a $summary_file
 }
 
 function print_iops  {
-  printf "[RESULT] IOPS phase $1 %25s %20.3f kiops : time %6.2f seconds\n" $phase $2 $3 | tee -a $summary_file
+  printf "[RESULT$4] IOPS phase $1 %25s %20.3f kiops : time %6.2f seconds\n" $phase $2 $3 | tee -a $summary_file
 }
 
 function startphase {
@@ -304,16 +316,24 @@ function startphase {
 
 function endphase_check  {
   r=$?
+  local op="$1"
+
   if [[ "$r" != "0" ]] ; then
      echo "Error: the benchmark returned $r"
      exit 1
   fi
-  end=`date +%s.%N`
-  duration=`echo "$end - $start" | bc`
-  duration=`printf %.4f $duration`
+  end=$(date +%s.%N)
+  duration=$(printf "%.4f" $(echo "$end - $start" | bc))
 
-  if [[ `printf "%.0f" $duration` -le 300 && "$1" == "write" ]] ; then
-    echo "[Warning] This cannot be official score. The runtime of $duration seconds is below 5 minutes"
+  if [[  "$op" == "write" && $(printf "%.0f" $duration) -lt 300 ]] ; then
+    local var="$2"
+
+    echo "[Warning] This cannot be an official IO-500 score. The phase runtime of ${duration}s is below 300s."
+    echo "[Warning] Suggest $var=$(echo "${!var} * 320 / $duration" | bc)"
+    io500_invalid="-invalid"
+    invalid="-invalid"
+  else
+    invalid=""
   fi
 }
 

--- a/utilities/io500_fixed.sh
+++ b/utilities/io500_fixed.sh
@@ -42,15 +42,13 @@ function output_description {
 }
 
 function check_variables {
-  # anyone know a way to do this crap with a helper function?
-  [ -z "$io500_workdir" ]                    && echo "Need to set io500_workdir variable"           && exit 1
-  [ -z "$io500_ior_easy_params" ]            && echo "Need to set io500_ior_easy_params variable"   && exit 1
-  [ -z "$io500_mdtest_hard_files_per_proc" ] && echo "Need to set io500_mdtest_hard_files_per_proc variable" && exit 1
-  [ -z "$io500_ior_hard_writes_per_proc" ]   && echo "Need to set io500_ior_hard_writes_per_proc variable" && exit 1
-  [ -z "$io500_find_cmd" ]                   && echo "Need to set io500_find_cmd variable" && exit 1
-  [ -z "$io500_ior_cmd" ]                    && echo "Need to set io500_ior_cmd variable" && exit 1
-  [ -z "$io500_mdtest_cmd" ]                 && echo "Need to set io500_mdtest_cmd variable" && exit 1
-  [ -z "$io500_mpirun" ]                     && echo "Need to set io500_mpirun variable" && exit 1
+  local important_vars="io500_workdir io500_ior_easy_params io500_mdtest_hard_files_per_proc io500_ior_hard_writes_per_proc io500_find_cmd io500_ior_cmd io500_mdtest_cmd io500_mpirun"
+
+  for V in $important_vars; do
+    [ -z "${!V}" -o "${!V}" = "xxx" ] &&
+      echo "Need to set '$V' in io500.sh" && exit 1
+  done
+
   return 0
 }
 


### PR DESCRIPTION
Check that each of the `write` test results is valid for IO-500 submission (more than 300s in duration).  Print out an `-invalid` marker with each invalid result and with the final `SCORE`, otherwise it is difficult to know whether a result is valid.