### PR TITLE
Update io500.sh

### DIFF
--- a/io500.sh
+++ b/io500.sh
@@ -110,8 +110,8 @@ function setup_find {
   #   Then you can set io500_find_mpi to be "False" and write a wrapper
   #   script for this which sets up MPI as you would like.  Then change
   #   io500_find_cmd to point to your wrapper script.
-  io500_find_mpi="False"
-  io500_find_cmd="$PWD/bin/sfind.sh"
+  io500_find_mpi="True"
+  io500_find_cmd="$PWD/bin/pfind"
   # uses stonewalling, run pfind
   io500_find_cmd_args=""
 


### PR DESCRIPTION
Under the parallel find section, we were still using the sfind.sh which usually doesn't find matches for the find. I tried on two systems and I had to change the pfind. So, the proposal is to use pfind by default. Moreover the binary of pfind was not declared to the variable.