### PR TITLE
prepare.sh: fix up tags to actual values

### DIFF
--- a/utilities/prepare.sh
+++ b/utilities/prepare.sh
@@ -7,7 +7,7 @@ echo It will also attempt to build the benchmarks
 echo It will output OK at the end if builds succeed
 echo
 
-IOR_HASH=io500-isc20
+IOR_HASH=48eb1880
 MDREAL_HASH=io500-isc20
 
 INSTALL_DIR=$PWD


### PR DESCRIPTION
Fix the IOR_HASH value to use the same value as io500-app.